### PR TITLE
Escape semicolen when in S text

### DIFF
--- a/puzzlebox.c
+++ b/puzzlebox.c
@@ -429,7 +429,7 @@ main (int argc, const char *argv[])
                   char *p = strdupa (*(char * *) optionsTable[o].arg),
                      *q;
                   for (q = p; *q; q++)
-                     if (*q <= ' ' || *q == '/' || *q == '\\' || *q == '"' || *q == '\'' || *q == ':')
+                     if (*q <= ' ' || *q == '/' || *q == '\\' || *q == '"' || *q == '\'' || *q == ':' || *q == ';')
                         *q = '_';
                   printf ("-%c%s", optionsTable[o].shortName, p);
                }


### PR DESCRIPTION
This should resolve https://github.com/revk/PuzzleBox/issues/9 as the filename in the chrome debugger shows that the file name ends at a ';' character.

![image](https://user-images.githubusercontent.com/8085744/146255843-42112623-68a7-4093-9e6c-be33c3d1dded.png)
